### PR TITLE
feat: initial working commit

### DIFF
--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,0 +1,7 @@
+####
+## This is managed via https://github.com/internal-GlueOps/github-shared-files-sync . Any changes to this file may be overridden by our automation
+####
+
+include-in-release-notes:
+- changed-files:
+  - any-glob-to-any-file: '**'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+####
+## This is managed via https://github.com/internal-GlueOps/github-shared-files-sync . Any changes to this file may be overridden by our automation
+####
+
+changelog:
+  exclude:
+    labels:
+      - 'ignore'
+    # authors:
+    #   - 'glueops-terraform-svc-account'
+    #   - 'glueops-svc-account'
+    #   - 'glueops-renovatebot'
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - 'major'
+        - 'breaking-change'
+    - title: Enhancements 🎉
+      labels:
+        - 'minor'
+        - 'enhancement'
+        - 'new-feature'
+    - title: Other 🐛
+      labels:
+        - 'auto-update'
+        - 'patch'
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+        - 'hotfix'
+        - 'dependencies'
+        - 'include-in-release-notes'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: Generate terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"
+        git-commit-message: "docs: automated update of terraform docs"

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,2 @@
+formatter: "markdown" # this is required
+header-from: "docs/.header.md"

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ No resources.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_backup_plan_arns"></a> [backup\_plan\_arns](#output\_backup\_plan\_arns) | Map of region to backup plan ARN |
-| <a name="output_backup_plan_ids"></a> [backup\_plan\_ids](#output\_backup\_plan\_ids) | Map of region to backup plan ID |
 | <a name="output_backup_vault_arns"></a> [backup\_vault\_arns](#output\_backup\_vault\_arns) | Map of region to backup vault ARN |
 | <a name="output_backup_vault_ids"></a> [backup\_vault\_ids](#output\_backup\_vault\_ids) | Map of region to backup vault ID |
+| <a name="output_continuous_backup_plan_arns"></a> [continuous\_backup\_plan\_arns](#output\_continuous\_backup\_plan\_arns) | Map of region to continuous backup plan ARN |
+| <a name="output_continuous_backup_plan_ids"></a> [continuous\_backup\_plan\_ids](#output\_continuous\_backup\_plan\_ids) | Map of region to continuous backup plan ID |
+| <a name="output_snapshot_backup_plan_arns"></a> [snapshot\_backup\_plan\_arns](#output\_snapshot\_backup\_plan\_arns) | Map of region to snapshot backup plan ARN |
+| <a name="output_snapshot_backup_plan_ids"></a> [snapshot\_backup\_plan\_ids](#output\_snapshot\_backup\_plan\_ids) | Map of region to snapshot backup plan ID |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,88 @@
 <!-- BEGIN_TF_DOCS -->
+# opentofu-module-aws-backup
+
+A multi-region AWS Backup module that creates backup vaults across multiple regions with automatic cross-region replication. Simply pass in an array of regions and the module handles the rest.
+
+## Features
+
+- **Multi-Region Support**: Pass an array of regions, get vaults in all of them
+- **Automatic Cross-Region Replication**: Each region automatically copies backups to all other regions
+- **S3 Bucket Backup**: Backs up all S3 buckets with continuous and snapshot backups
+- **Continuous Backup**: Point-in-time restore for S3 (max 35 days retention)
+- **Hourly Snapshots**: Regular snapshot backups with configurable retention
+- **Smart Exclusions**: Automatically excludes S3 buckets with `-loki-` in their name
+- **Vault Lock (Compliance Mode)**: Optional immutable backup retention enforcement
+- **Minimal Configuration**: Only requires `tenant_key` and `regions` array
+- **Role Assumption**: Optional IAM role assumption for cross-account scenarios
+
+## Architecture
+
+For a 3-region setup (us-west-2, us-east-1, us-east-2):
+
+```
+┌─────────────────────────────────────────────────┐
+│ us-west-2                                       │
+│ - Creates vault in us-west-2                    │
+│ - Backs up S3 buckets in us-west-2             │
+│ - Copies to: us-east-1, us-east-2              │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ us-east-1                                       │
+│ - Creates vault in us-east-1                    │
+│ - Backs up S3 buckets in us-east-1             │
+│ - Copies to: us-west-2, us-east-2              │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ us-east-2                                       │
+│ - Creates vault in us-east-2                    │
+│ - Backs up S3 buckets in us-east-2             │
+│ - Copies to: us-west-2, us-east-1              │
+└─────────────────────────────────────────────────┘
+```
+
+## Usage
+
+### Basic Example
+
+```hcl
+module "backup" {
+  source = "git::https://github.com/GlueOps/opentofu-module-aws-backup.git?ref=main"
+
+  tenant_key = "my-company"
+  regions = [
+    "us-west-2",
+    "us-east-2"
+  ]
+}
+```
+
+### Full Configuration
+
+```hcl
+module "backup" {
+  source = "git::https://github.com/GlueOps/opentofu-module-aws-backup.git?ref=main"
+
+  tenant_key = "my-company"
+  regions = [
+    "us-west-2",
+    "us-east-1",
+    "us-east-2"
+  ]
+  # Optional: IAM role to assume for AWS API calls
+  assume_role_arn = "arn:aws:iam::123456789012:role/BackupRole"
+  # Retention settings
+  backup_retention_days            = 7   # Snapshot backups and copies (default: 7)
+  continuous_backup_retention_days = 35  # Continuous backups, max 35 days (default: 35)
+  # Vault lock (compliance mode) - prevents backup deletion
+  enable_vault_lock              = true  # Enable compliance mode (default: true)
+  vault_lock_changeable_days     = 365   # Days to modify lock before immutable (default: 365)
+  vault_lock_min_retention_days  = 1     # Minimum retention enforced (default: 1)
+  vault_lock_max_retention_days  = 365   # Maximum retention enforced (default: 365)
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module "backup" {
   enable_vault_lock              = true  # Enable compliance mode (default: true)
   vault_lock_changeable_days     = 365   # Days to modify lock before immutable (default: 365)
   vault_lock_min_retention_days  = 1     # Minimum retention enforced (default: 1)
-  vault_lock_max_retention_days  = 365   # Maximum retention enforced (default: 365)
+  vault_lock_max_retention_days  = 120   # Maximum retention enforced (default: 120)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A multi-region AWS Backup module that creates backup vaults across multiple regi
 - **Smart Exclusions**: Automatically excludes S3 buckets with `-loki-` in their name
 - **Vault Lock (Compliance Mode)**: Optional immutable backup retention enforcement
 - **Minimal Configuration**: Only requires `tenant_key` and `regions` array
-- **Role Assumption**: Optional IAM role assumption for cross-account scenarios
+- **Role Assumption**: IAM role assumption for cross-account scenarios
 
 ## Architecture
 
@@ -71,7 +71,7 @@ module "backup" {
     "us-east-2"
   ]
   # Optional: IAM role to assume for AWS API calls
-  assume_role_arn = "arn:aws:iam::123456789012:role/BackupRole"
+  assume_role_arn = "arn:aws:iam::123456789012:role/OrganizationAccountAccessRole"
   # Retention settings
   backup_retention_days            = 7   # Snapshot backups and copies (default: 7)
   continuous_backup_retention_days = 35  # Continuous backups, max 35 days (default: 35)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,53 @@
 <!-- BEGIN_TF_DOCS -->
+## Requirements
 
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_backup_plan"></a> [backup\_plan](#module\_backup\_plan) | ./modules/backup-plan | n/a |
+| <a name="module_vault"></a> [vault](#module\_vault) | ./modules/vault | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assume_role_arn"></a> [assume\_role\_arn](#input\_assume\_role\_arn) | Optional IAM role ARN to assume for AWS API calls. If not provided, uses default credentials. | `string` | `null` | no |
+| <a name="input_backup_retention_days"></a> [backup\_retention\_days](#input\_backup\_retention\_days) | Number of days to retain backups in the primary vault | `number` | `7` | no |
+| <a name="input_continuous_backup_completion_window"></a> [continuous\_backup\_completion\_window](#input\_continuous\_backup\_completion\_window) | Number of minutes to complete the continuous backup after starting | `number` | `180` | no |
+| <a name="input_continuous_backup_retention_days"></a> [continuous\_backup\_retention\_days](#input\_continuous\_backup\_retention\_days) | Number of days to retain continuous backups (max 35 days for AWS Backup continuous backups) | `number` | `35` | no |
+| <a name="input_continuous_backup_schedule"></a> [continuous\_backup\_schedule](#input\_continuous\_backup\_schedule) | Cron expression for continuous backup (AWS default for continuous backup) | `string` | `"cron(0 5 ? * * *)"` | no |
+| <a name="input_continuous_backup_start_window"></a> [continuous\_backup\_start\_window](#input\_continuous\_backup\_start\_window) | Number of minutes to start the continuous backup after scheduled time | `number` | `60` | no |
+| <a name="input_enable_vault_lock"></a> [enable\_vault\_lock](#input\_enable\_vault\_lock) | Enable vault lock (compliance mode) to prevent backup deletion. Enabled by default for data protection. | `bool` | `true` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | List of AWS regions where backup vaults will be created | `list(string)` | n/a | yes |
+| <a name="input_snapshot_completion_window"></a> [snapshot\_completion\_window](#input\_snapshot\_completion\_window) | Number of minutes to complete the snapshot backup after starting | `number` | `180` | no |
+| <a name="input_snapshot_schedule"></a> [snapshot\_schedule](#input\_snapshot\_schedule) | Cron expression for snapshot backup schedule | `string` | `"cron(0 * * * ? *)"` | no |
+| <a name="input_snapshot_start_window"></a> [snapshot\_start\_window](#input\_snapshot\_start\_window) | Number of minutes to start the snapshot backup after scheduled time | `number` | `60` | no |
+| <a name="input_tenant_key"></a> [tenant\_key](#input\_tenant\_key) | The tenant identifier used for naming and tagging resources | `string` | n/a | yes |
+| <a name="input_vault_lock_changeable_days"></a> [vault\_lock\_changeable\_days](#input\_vault\_lock\_changeable\_days) | Number of days the vault lock can be changed before becoming immutable. Set to 0 to make it immediately immutable. | `number` | `365` | no |
+| <a name="input_vault_lock_max_retention_days"></a> [vault\_lock\_max\_retention\_days](#input\_vault\_lock\_max\_retention\_days) | Maximum number of days backups can be retained (compliance requirement) | `number` | `120` | no |
+| <a name="input_vault_lock_min_retention_days"></a> [vault\_lock\_min\_retention\_days](#input\_vault\_lock\_min\_retention\_days) | Minimum number of days backups must be retained (compliance requirement) | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_backup_plan_arns"></a> [backup\_plan\_arns](#output\_backup\_plan\_arns) | Map of region to backup plan ARN |
+| <a name="output_backup_plan_ids"></a> [backup\_plan\_ids](#output\_backup\_plan\_ids) | Map of region to backup plan ID |
+| <a name="output_backup_vault_arns"></a> [backup\_vault\_arns](#output\_backup\_vault\_arns) | Map of region to backup vault ARN |
+| <a name="output_backup_vault_ids"></a> [backup\_vault\_ids](#output\_backup\_vault\_ids) | Map of region to backup vault ID |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# opentofu-module-aws-backup
-Managed by github-org-manager
+<!-- BEGIN_TF_DOCS -->
+
+<!-- END_TF_DOCS -->

--- a/backup.tf
+++ b/backup.tf
@@ -3,7 +3,7 @@ provider "aws" {
   alias    = "by_region"
   for_each = toset(var.regions)
   region   = each.value
-  
+
   dynamic "assume_role" {
     for_each = var.assume_role_arn != null ? [1] : []
     content {
@@ -22,45 +22,45 @@ locals {
 module "vault" {
   source   = "./modules/vault"
   for_each = local.regions_map
-  
+
   providers = {
     aws = aws.by_region[each.key]
   }
-  
-  tenant_key                     = var.tenant_key
-  region                         = each.value
-  enable_vault_lock              = var.enable_vault_lock
-  vault_lock_changeable_days     = var.vault_lock_changeable_days
-  vault_lock_min_retention_days  = var.vault_lock_min_retention_days
-  vault_lock_max_retention_days  = var.vault_lock_max_retention_days
+
+  tenant_key                    = var.tenant_key
+  region                        = each.value
+  enable_vault_lock             = var.enable_vault_lock
+  vault_lock_changeable_days    = var.vault_lock_changeable_days
+  vault_lock_min_retention_days = var.vault_lock_min_retention_days
+  vault_lock_max_retention_days = var.vault_lock_max_retention_days
 }
 
 # STAGE 2: Create backup plans with cross-region copy after vaults exist
 module "backup_plan" {
   source   = "./modules/backup-plan"
   for_each = local.regions_map
-  
+
   providers = {
     aws = aws.by_region[each.key]
   }
-  
-  tenant_key            = var.tenant_key
-  region                = each.value
-  backup_vault_name     = module.vault[each.key].backup_vault_name
-  backup_vault_arn      = module.vault[each.key].backup_vault_arn
-  backup_retention_days = var.backup_retention_days
+
+  tenant_key                       = var.tenant_key
+  region                           = each.value
+  backup_vault_name                = module.vault[each.key].backup_vault_name
+  backup_vault_arn                 = module.vault[each.key].backup_vault_arn
+  backup_retention_days            = var.backup_retention_days
   continuous_backup_retention_days = var.continuous_backup_retention_days
-  
+
   # Snapshot backup settings
-  snapshot_schedule           = var.snapshot_schedule
-  snapshot_start_window       = var.snapshot_start_window
-  snapshot_completion_window  = var.snapshot_completion_window
-  
+  snapshot_schedule          = var.snapshot_schedule
+  snapshot_start_window      = var.snapshot_start_window
+  snapshot_completion_window = var.snapshot_completion_window
+
   # Continuous backup settings
   continuous_backup_schedule          = var.continuous_backup_schedule
   continuous_backup_start_window      = var.continuous_backup_start_window
   continuous_backup_completion_window = var.continuous_backup_completion_window
-  
+
   # Pass ALL vault ARNs as map for cross-region copy
   all_vault_arns = {
     for dest in var.regions : dest => module.vault[dest].backup_vault_arn

--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,68 @@
+# Define a provider for each region
+provider "aws" {
+  alias    = "by_region"
+  for_each = toset(var.regions)
+  region   = each.value
+  
+  dynamic "assume_role" {
+    for_each = var.assume_role_arn != null ? [1] : []
+    content {
+      role_arn = var.assume_role_arn
+    }
+  }
+}
+
+# Local variables
+locals {
+  # Create a map for easy iteration
+  regions_map = { for idx, region in var.regions : region => region }
+}
+
+# STAGE 1: Create vaults in all regions first
+module "vault" {
+  source   = "./modules/vault"
+  for_each = local.regions_map
+  
+  providers = {
+    aws = aws.by_region[each.key]
+  }
+  
+  tenant_key                     = var.tenant_key
+  region                         = each.value
+  enable_vault_lock              = var.enable_vault_lock
+  vault_lock_changeable_days     = var.vault_lock_changeable_days
+  vault_lock_min_retention_days  = var.vault_lock_min_retention_days
+  vault_lock_max_retention_days  = var.vault_lock_max_retention_days
+}
+
+# STAGE 2: Create backup plans with cross-region copy after vaults exist
+module "backup_plan" {
+  source   = "./modules/backup-plan"
+  for_each = local.regions_map
+  
+  providers = {
+    aws = aws.by_region[each.key]
+  }
+  
+  tenant_key            = var.tenant_key
+  region                = each.value
+  backup_vault_name     = module.vault[each.key].backup_vault_name
+  backup_vault_arn      = module.vault[each.key].backup_vault_arn
+  backup_retention_days = var.backup_retention_days
+  continuous_backup_retention_days = var.continuous_backup_retention_days
+  
+  # Snapshot backup settings
+  snapshot_schedule           = var.snapshot_schedule
+  snapshot_start_window       = var.snapshot_start_window
+  snapshot_completion_window  = var.snapshot_completion_window
+  
+  # Continuous backup settings
+  continuous_backup_schedule          = var.continuous_backup_schedule
+  continuous_backup_start_window      = var.continuous_backup_start_window
+  continuous_backup_completion_window = var.continuous_backup_completion_window
+  
+  # Pass ALL vault ARNs as map for cross-region copy
+  all_vault_arns = {
+    for dest in var.regions : dest => module.vault[dest].backup_vault_arn
+  }
+}

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -12,7 +12,7 @@ A multi-region AWS Backup module that creates backup vaults across multiple regi
 - **Smart Exclusions**: Automatically excludes S3 buckets with `-loki-` in their name
 - **Vault Lock (Compliance Mode)**: Optional immutable backup retention enforcement
 - **Minimal Configuration**: Only requires `tenant_key` and `regions` array
-- **Role Assumption**: Optional IAM role assumption for cross-account scenarios
+- **Role Assumption**: IAM role assumption for cross-account scenarios
 
 ## Architecture
 
@@ -73,7 +73,7 @@ module "backup" {
   ]
   
   # Optional: IAM role to assume for AWS API calls
-  assume_role_arn = "arn:aws:iam::123456789012:role/BackupRole"
+  assume_role_arn = "arn:aws:iam::123456789012:role/OrganizationAccountAccessRole"
   
   # Retention settings
   backup_retention_days            = 7   # Snapshot backups and copies (default: 7)

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -83,6 +83,6 @@ module "backup" {
   enable_vault_lock              = true  # Enable compliance mode (default: true)
   vault_lock_changeable_days     = 365   # Days to modify lock before immutable (default: 365)
   vault_lock_min_retention_days  = 1     # Minimum retention enforced (default: 1)
-  vault_lock_max_retention_days  = 365   # Maximum retention enforced (default: 365)
+  vault_lock_max_retention_days  = 120   # Maximum retention enforced (default: 120)
 }
 ```

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -1,0 +1,88 @@
+# opentofu-module-aws-backup
+
+A multi-region AWS Backup module that creates backup vaults across multiple regions with automatic cross-region replication. Simply pass in an array of regions and the module handles the rest.
+
+## Features
+
+- **Multi-Region Support**: Pass an array of regions, get vaults in all of them
+- **Automatic Cross-Region Replication**: Each region automatically copies backups to all other regions
+- **S3 Bucket Backup**: Backs up all S3 buckets with continuous and snapshot backups
+- **Continuous Backup**: Point-in-time restore for S3 (max 35 days retention)
+- **Hourly Snapshots**: Regular snapshot backups with configurable retention
+- **Smart Exclusions**: Automatically excludes S3 buckets with `-loki-` in their name
+- **Vault Lock (Compliance Mode)**: Optional immutable backup retention enforcement
+- **Minimal Configuration**: Only requires `tenant_key` and `regions` array
+- **Role Assumption**: Optional IAM role assumption for cross-account scenarios
+
+## Architecture
+
+For a 3-region setup (us-west-2, us-east-1, us-east-2):
+
+```
+┌─────────────────────────────────────────────────┐
+│ us-west-2                                       │
+│ - Creates vault in us-west-2                    │
+│ - Backs up S3 buckets in us-west-2             │
+│ - Copies to: us-east-1, us-east-2              │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ us-east-1                                       │
+│ - Creates vault in us-east-1                    │
+│ - Backs up S3 buckets in us-east-1             │
+│ - Copies to: us-west-2, us-east-2              │
+└─────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────┐
+│ us-east-2                                       │
+│ - Creates vault in us-east-2                    │
+│ - Backs up S3 buckets in us-east-2             │
+│ - Copies to: us-west-2, us-east-1              │
+└─────────────────────────────────────────────────┘
+```
+
+## Usage
+
+### Basic Example
+
+```hcl
+module "backup" {
+  source = "git::https://github.com/GlueOps/opentofu-module-aws-backup.git?ref=main"
+
+  tenant_key = "my-company"
+  
+  regions = [
+    "us-west-2",
+    "us-east-2"
+  ]
+}
+```
+
+### Full Configuration
+
+```hcl
+module "backup" {
+  source = "git::https://github.com/GlueOps/opentofu-module-aws-backup.git?ref=main"
+
+  tenant_key = "my-company"
+  
+  regions = [
+    "us-west-2",
+    "us-east-1",
+    "us-east-2"
+  ]
+  
+  # Optional: IAM role to assume for AWS API calls
+  assume_role_arn = "arn:aws:iam::123456789012:role/BackupRole"
+  
+  # Retention settings
+  backup_retention_days            = 7   # Snapshot backups and copies (default: 7)
+  continuous_backup_retention_days = 35  # Continuous backups, max 35 days (default: 35)
+  
+  # Vault lock (compliance mode) - prevents backup deletion
+  enable_vault_lock              = true  # Enable compliance mode (default: true)
+  vault_lock_changeable_days     = 365   # Days to modify lock before immutable (default: 365)
+  vault_lock_min_retention_days  = 1     # Minimum retention enforced (default: 1)
+  vault_lock_max_retention_days  = 365   # Maximum retention enforced (default: 365)
+}
+```

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,22 @@
+module "multi_region_backup" {
+  source = "../../"
+
+  tenant_key = "acme-corp"
+  
+  regions = [
+    "us-west-2",
+    "us-east-2",
+    "us-east-1",
+    "eu-north-1"
+  ]
+  
+  # Retention settings
+  backup_retention_days            = 1   # Retention for snapshot backups and copies
+  continuous_backup_retention_days = 1   # Retention for continuous backups (max 35 days)
+  
+  # Vault lock settings (compliance mode with long changeable window)
+  enable_vault_lock              = false   # Enable compliance mode
+  vault_lock_changeable_days     = 365    # 1 year to modify lock settings
+  vault_lock_min_retention_days  = 1      # Minimum retention enforced
+  vault_lock_max_retention_days  = 90      # Maximum retention enforced
+}

--- a/modules/backup-plan/main.tf
+++ b/modules/backup-plan/main.tf
@@ -1,0 +1,125 @@
+# Generate UUIDs for unique resource naming
+resource "random_uuid" "role" {}
+resource "random_uuid" "plan" {}
+resource "random_uuid" "selection" {}
+
+# Local variables
+locals {
+  # UUIDs for unique naming
+  role_uuid      = random_uuid.role.result
+  plan_uuid      = random_uuid.plan.result
+  selection_uuid = random_uuid.selection.result
+}
+
+# Create IAM role for AWS Backup
+resource "aws_iam_role" "backup" {
+  name = local.role_uuid
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "backup.amazonaws.com"
+        }
+      }
+    ]
+  })
+  
+  tags = {
+    Name        = "${var.tenant_key}-${var.region}-backup-role"
+    tenant_name = var.tenant_key
+    region      = var.region
+    managed_by  = "opentofu"
+    uuid        = local.role_uuid
+  }
+}
+
+# Attach AWS managed policies
+resource "aws_iam_role_policy_attachment" "backup_policies" {
+  for_each = toset([
+    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores",
+  ])
+  
+  role       = aws_iam_role.backup.name
+  policy_arn = each.value
+}
+
+# Create backup plan with continuous backup and cross-region copy
+resource "aws_backup_plan" "this" {
+  name = local.plan_uuid
+
+  # Continuous backup rule (for supported resources like S3)
+  rule {
+    rule_name                = "continuous-backup"
+    target_vault_name        = var.backup_vault_name
+    enable_continuous_backup = true
+    schedule                 = var.continuous_backup_schedule
+    start_window             = var.continuous_backup_start_window
+    completion_window        = var.continuous_backup_completion_window
+
+    lifecycle {
+      delete_after = 35
+    }
+
+    # Copy to all vaults including same-region (AWS handles this correctly)
+    dynamic "copy_action" {
+      for_each = var.all_vault_arns
+      content {
+        destination_vault_arn = copy_action.value
+
+        lifecycle {
+          delete_after = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  # Snapshot backup rule (hourly for all resources)
+  rule {
+    rule_name         = "hourly-snapshot-backup"
+    target_vault_name = var.backup_vault_name
+    schedule          = var.snapshot_schedule
+    start_window      = var.snapshot_start_window
+    completion_window = var.snapshot_completion_window
+
+    lifecycle {
+      delete_after = var.backup_retention_days
+    }
+
+    # Copy snapshots to all vaults including same-region (AWS handles this correctly)
+    dynamic "copy_action" {
+      for_each = var.all_vault_arns
+      content {
+        destination_vault_arn = copy_action.value
+
+        lifecycle {
+          delete_after = var.backup_retention_days
+        }
+      }
+    }
+  }
+
+  tags = {
+    Name        = "${var.tenant_key}-${var.region}-backup-plan"
+    tenant_name = var.tenant_key
+    region      = var.region
+    managed_by  = "opentofu"
+    uuid        = local.plan_uuid
+  }
+}
+
+# Create backup selection for S3 buckets (excluding -loki- buckets)
+resource "aws_backup_selection" "s3" {
+  iam_role_arn = aws_iam_role.backup.arn
+  name         = local.selection_uuid
+  plan_id      = aws_backup_plan.this.id
+
+  resources = ["arn:aws:s3:::*"]
+  
+  # Exclude buckets with -loki- in the name
+  not_resources = ["arn:aws:s3:::*-loki-*"]
+}

--- a/modules/backup-plan/main.tf
+++ b/modules/backup-plan/main.tf
@@ -71,6 +71,13 @@ resource "aws_backup_plan" "continuous" {
       delete_after = var.continuous_backup_retention_days
     }
 
+    recovery_point_tags = {
+      backup_type = "continuous"
+      tenant_name = var.tenant_key
+      region      = var.region
+      managed_by  = "opentofu"
+    }
+
     # Copy to all vaults including same-region (AWS handles this correctly)
     dynamic "copy_action" {
       for_each = var.all_vault_arns
@@ -107,6 +114,13 @@ resource "aws_backup_plan" "snapshot" {
 
     lifecycle {
       delete_after = var.backup_retention_days
+    }
+
+    recovery_point_tags = {
+      backup_type = "snapshot"
+      tenant_name = var.tenant_key
+      region      = var.region
+      managed_by  = "opentofu"
     }
 
     # Copy snapshots to all vaults including same-region (AWS handles this correctly)

--- a/modules/backup-plan/main.tf
+++ b/modules/backup-plan/main.tf
@@ -42,6 +42,8 @@ resource "aws_iam_role_policy_attachment" "backup_policies" {
   for_each = toset([
     "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
     "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores",
+    "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup",
+    "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore",
   ])
   
   role       = aws_iam_role.backup.name

--- a/modules/backup-plan/main.tf
+++ b/modules/backup-plan/main.tf
@@ -62,7 +62,7 @@ resource "aws_backup_plan" "this" {
     completion_window        = var.continuous_backup_completion_window
 
     lifecycle {
-      delete_after = 35
+      delete_after = var.continuous_backup_retention_days
     }
 
     # Copy to all vaults including same-region (AWS handles this correctly)

--- a/modules/backup-plan/outputs.tf
+++ b/modules/backup-plan/outputs.tf
@@ -1,0 +1,14 @@
+output "backup_plan_id" {
+  description = "ID of the backup plan"
+  value       = aws_backup_plan.this.id
+}
+
+output "backup_plan_arn" {
+  description = "ARN of the backup plan"
+  value       = aws_backup_plan.this.arn
+}
+
+output "backup_selection_id" {
+  description = "ID of the backup selection"
+  value       = aws_backup_selection.s3.id
+}

--- a/modules/backup-plan/outputs.tf
+++ b/modules/backup-plan/outputs.tf
@@ -1,14 +1,29 @@
-output "backup_plan_id" {
-  description = "ID of the backup plan"
-  value       = aws_backup_plan.this.id
+output "continuous_backup_plan_id" {
+  description = "ID of the continuous backup plan"
+  value       = aws_backup_plan.continuous.id
 }
 
-output "backup_plan_arn" {
-  description = "ARN of the backup plan"
-  value       = aws_backup_plan.this.arn
+output "continuous_backup_plan_arn" {
+  description = "ARN of the continuous backup plan"
+  value       = aws_backup_plan.continuous.arn
 }
 
-output "backup_selection_id" {
-  description = "ID of the backup selection"
-  value       = aws_backup_selection.s3.id
+output "snapshot_backup_plan_id" {
+  description = "ID of the snapshot backup plan"
+  value       = aws_backup_plan.snapshot.id
+}
+
+output "snapshot_backup_plan_arn" {
+  description = "ARN of the snapshot backup plan"
+  value       = aws_backup_plan.snapshot.arn
+}
+
+output "continuous_backup_selection_id" {
+  description = "ID of the continuous backup selection"
+  value       = aws_backup_selection.continuous.id
+}
+
+output "snapshot_backup_selection_id" {
+  description = "ID of the snapshot backup selection"
+  value       = aws_backup_selection.snapshot.id
 }

--- a/modules/backup-plan/variables.tf
+++ b/modules/backup-plan/variables.tf
@@ -1,0 +1,73 @@
+variable "tenant_key" {
+  description = "Unique identifier for the tenant"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for this backup plan"
+  type        = string
+}
+
+variable "backup_vault_name" {
+  description = "Name of the backup vault to use"
+  type        = string
+}
+
+variable "backup_vault_arn" {
+  description = "ARN of the backup vault (for reference)"
+  type        = string
+}
+
+variable "all_vault_arns" {
+  description = "Map of region to vault ARN for cross-region copy"
+  type        = map(string)
+  default     = {}
+}
+
+variable "backup_retention_days" {
+  description = "Number of days to retain backups in the primary vault"
+  type        = number
+  default     = 7
+}
+
+variable "continuous_backup_retention_days" {
+  description = "Number of days to retain continuous backups (max 35 days)"
+  type        = number
+  default     = 35
+}
+
+variable "snapshot_schedule" {
+  description = "Cron expression for snapshot backup schedule"
+  type        = string
+  default     = "cron(0 * * * ? *)"  # Hourly
+}
+
+variable "snapshot_start_window" {
+  description = "Number of minutes to start the snapshot backup after scheduled time"
+  type        = number
+  default     = 60
+}
+
+variable "snapshot_completion_window" {
+  description = "Number of minutes to complete the snapshot backup after starting"
+  type        = number
+  default     = 180
+}
+
+variable "continuous_backup_schedule" {
+  description = "Cron expression for continuous backup"
+  type        = string
+  default     = "cron(0 5 ? * * *)"  # Daily at 5 AM UTC
+}
+
+variable "continuous_backup_start_window" {
+  description = "Number of minutes to start the continuous backup after scheduled time"
+  type        = number
+  default     = 60
+}
+
+variable "continuous_backup_completion_window" {
+  description = "Number of minutes to complete the continuous backup after starting"
+  type        = number
+  default     = 180
+}

--- a/modules/backup-plan/versions.tf
+++ b/modules/backup-plan/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1,0 +1,35 @@
+# Generate UUID for unique resource naming
+resource "random_uuid" "vault" {}
+
+# Local variables
+locals {
+  # UUID for unique naming
+  uuid = random_uuid.vault.result
+}
+
+# Create a backup vault for this region
+resource "aws_backup_vault" "this" {
+  name          = local.uuid
+  force_destroy = var.enable_vault_lock ? false : true
+  
+  tags = {
+    Name        = "${var.tenant_key}-${var.region}-backup"
+    tenant_name = var.tenant_key
+    region      = var.region
+    managed_by  = "opentofu"
+    uuid        = local.uuid
+  }
+}
+
+# Enable vault lock (compliance mode) if enabled
+resource "aws_backup_vault_lock_configuration" "this" {
+  count = var.enable_vault_lock ? 1 : 0
+  
+  backup_vault_name   = aws_backup_vault.this.name
+  changeable_for_days = var.vault_lock_changeable_days
+  min_retention_days  = var.vault_lock_min_retention_days
+  max_retention_days  = var.vault_lock_max_retention_days
+  
+  # IMPORTANT: This enables COMPLIANCE mode (prevents deletion even by root)
+  # Without this, it's governance mode (can be overridden with permissions)
+}

--- a/modules/vault/outputs.tf
+++ b/modules/vault/outputs.tf
@@ -1,0 +1,14 @@
+output "backup_vault_name" {
+  description = "Name of the backup vault"
+  value       = aws_backup_vault.this.name
+}
+
+output "backup_vault_arn" {
+  description = "ARN of the backup vault"
+  value       = aws_backup_vault.this.arn
+}
+
+output "backup_vault_id" {
+  description = "ID of the backup vault"
+  value       = aws_backup_vault.this.id
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,0 +1,33 @@
+variable "tenant_key" {
+  description = "Unique identifier for the tenant"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for this vault"
+  type        = string
+}
+
+variable "enable_vault_lock" {
+  description = "Enable vault lock (compliance mode) to prevent backup deletion"
+  type        = bool
+  default     = true
+}
+
+variable "vault_lock_changeable_days" {
+  description = "Number of days the vault lock can be changed before becoming immutable"
+  type        = number
+  default     = 365
+}
+
+variable "vault_lock_min_retention_days" {
+  description = "Minimum number of days backups must be retained"
+  type        = number
+  default     = 1
+}
+
+variable "vault_lock_max_retention_days" {
+  description = "Maximum number of days backups can be retained"
+  type        = number
+  default     = 7
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -29,5 +29,5 @@ variable "vault_lock_min_retention_days" {
 variable "vault_lock_max_retention_days" {
   description = "Maximum number of days backups can be retained"
   type        = number
-  default     = 7
+  default     = 120
 }

--- a/modules/vault/versions.tf
+++ b/modules/vault/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,16 +12,30 @@ output "backup_vault_ids" {
   }
 }
 
-output "backup_plan_ids" {
-  description = "Map of region to backup plan ID"
+output "continuous_backup_plan_ids" {
+  description = "Map of region to continuous backup plan ID"
   value = {
-    for region, plan in module.backup_plan : region => plan.backup_plan_id
+    for region, plan in module.backup_plan : region => plan.continuous_backup_plan_id
   }
 }
 
-output "backup_plan_arns" {
-  description = "Map of region to backup plan ARN"
+output "snapshot_backup_plan_ids" {
+  description = "Map of region to snapshot backup plan ID"
   value = {
-    for region, plan in module.backup_plan : region => plan.backup_plan_arn
+    for region, plan in module.backup_plan : region => plan.snapshot_backup_plan_id
+  }
+}
+
+output "continuous_backup_plan_arns" {
+  description = "Map of region to continuous backup plan ARN"
+  value = {
+    for region, plan in module.backup_plan : region => plan.continuous_backup_plan_arn
+  }
+}
+
+output "snapshot_backup_plan_arns" {
+  description = "Map of region to snapshot backup plan ARN"
+  value = {
+    for region, plan in module.backup_plan : region => plan.snapshot_backup_plan_arn
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,27 @@
+output "backup_vault_arns" {
+  description = "Map of region to backup vault ARN"
+  value = {
+    for region, vault in module.vault : region => vault.backup_vault_arn
+  }
+}
+
+output "backup_vault_ids" {
+  description = "Map of region to backup vault ID"
+  value = {
+    for region, vault in module.vault : region => vault.backup_vault_id
+  }
+}
+
+output "backup_plan_ids" {
+  description = "Map of region to backup plan ID"
+  value = {
+    for region, plan in module.backup_plan : region => plan.backup_plan_id
+  }
+}
+
+output "backup_plan_arns" {
+  description = "Map of region to backup plan ARN"
+  value = {
+    for region, plan in module.backup_plan : region => plan.backup_plan_arn
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "regions" {
   description = "List of AWS regions where backup vaults will be created"
   type        = list(string)
   nullable    = false
-  
+
   validation {
     condition     = length(var.regions) > 0
     error_message = "At least one region must be specified."
@@ -31,7 +31,7 @@ variable "continuous_backup_retention_days" {
   description = "Number of days to retain continuous backups (max 35 days for AWS Backup continuous backups)"
   type        = number
   default     = 35
-  
+
   validation {
     condition     = var.continuous_backup_retention_days >= 1 && var.continuous_backup_retention_days <= 35
     error_message = "Continuous backup retention must be between 1 and 35 days."
@@ -42,7 +42,7 @@ variable "continuous_backup_retention_days" {
 variable "snapshot_schedule" {
   description = "Cron expression for snapshot backup schedule"
   type        = string
-  default     = "cron(0 * * * ? *)"  # Hourly
+  default     = "cron(0 * * * ? *)" # Hourly
 }
 
 variable "snapshot_start_window" {
@@ -61,7 +61,7 @@ variable "snapshot_completion_window" {
 variable "continuous_backup_schedule" {
   description = "Cron expression for continuous backup (AWS default for continuous backup)"
   type        = string
-  default     = "cron(0 5 ? * * *)"  # Daily at 5 AM UTC
+  default     = "cron(0 5 ? * * *)" # Daily at 5 AM UTC
 }
 
 variable "continuous_backup_start_window" {
@@ -80,7 +80,7 @@ variable "continuous_backup_completion_window" {
 variable "vault_lock_changeable_days" {
   description = "Number of days the vault lock can be changed before becoming immutable. Set to 0 to make it immediately immutable."
   type        = number
-  default     = 365  # Long window for flexibility
+  default     = 365 # Long window for flexibility
 }
 
 variable "vault_lock_min_retention_days" {
@@ -92,7 +92,7 @@ variable "vault_lock_min_retention_days" {
 variable "vault_lock_max_retention_days" {
   description = "Maximum number of days backups can be retained (compliance requirement)"
   type        = number
-  default     = 120  # Short max retention by default
+  default     = 120 # Short max retention by default
 }
 
 variable "enable_vault_lock" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,102 @@
+variable "tenant_key" {
+  description = "The tenant identifier used for naming and tagging resources"
+  type        = string
+  nullable    = false
+}
+
+variable "regions" {
+  description = "List of AWS regions where backup vaults will be created"
+  type        = list(string)
+  nullable    = false
+  
+  validation {
+    condition     = length(var.regions) > 0
+    error_message = "At least one region must be specified."
+  }
+}
+
+variable "assume_role_arn" {
+  description = "Optional IAM role ARN to assume for AWS API calls. If not provided, uses default credentials."
+  type        = string
+  default     = null
+}
+
+variable "backup_retention_days" {
+  description = "Number of days to retain backups in the primary vault"
+  type        = number
+  default     = 7
+}
+
+variable "continuous_backup_retention_days" {
+  description = "Number of days to retain continuous backups (max 35 days for AWS Backup continuous backups)"
+  type        = number
+  default     = 35
+  
+  validation {
+    condition     = var.continuous_backup_retention_days >= 1 && var.continuous_backup_retention_days <= 35
+    error_message = "Continuous backup retention must be between 1 and 35 days."
+  }
+}
+
+# Snapshot backup settings
+variable "snapshot_schedule" {
+  description = "Cron expression for snapshot backup schedule"
+  type        = string
+  default     = "cron(0 * * * ? *)"  # Hourly
+}
+
+variable "snapshot_start_window" {
+  description = "Number of minutes to start the snapshot backup after scheduled time"
+  type        = number
+  default     = 60
+}
+
+variable "snapshot_completion_window" {
+  description = "Number of minutes to complete the snapshot backup after starting"
+  type        = number
+  default     = 180
+}
+
+# Continuous backup settings
+variable "continuous_backup_schedule" {
+  description = "Cron expression for continuous backup (AWS default for continuous backup)"
+  type        = string
+  default     = "cron(0 5 ? * * *)"  # Daily at 5 AM UTC
+}
+
+variable "continuous_backup_start_window" {
+  description = "Number of minutes to start the continuous backup after scheduled time"
+  type        = number
+  default     = 60
+}
+
+variable "continuous_backup_completion_window" {
+  description = "Number of minutes to complete the continuous backup after starting"
+  type        = number
+  default     = 180
+}
+
+# Vault lock settings
+variable "vault_lock_changeable_days" {
+  description = "Number of days the vault lock can be changed before becoming immutable. Set to 0 to make it immediately immutable."
+  type        = number
+  default     = 365  # Long window for flexibility
+}
+
+variable "vault_lock_min_retention_days" {
+  description = "Minimum number of days backups must be retained (compliance requirement)"
+  type        = number
+  default     = 1
+}
+
+variable "vault_lock_max_retention_days" {
+  description = "Maximum number of days backups can be retained (compliance requirement)"
+  type        = number
+  default     = 120  # Short max retention by default
+}
+
+variable "enable_vault_lock" {
+  description = "Enable vault lock (compliance mode) to prevent backup deletion. Enabled by default for data protection."
+  type        = bool
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.0"
-  
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Multi-region AWS Backup module with cross-region replication

- Automatic S3 bucket backup with continuous and snapshot options

- Vault lock compliance mode for immutable backup retention

- Comprehensive documentation and GitHub workflow automation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input: regions array"] --> B["Create vaults in all regions"]
  B --> C["Create backup plans with cross-region copy"]
  C --> D["Backup S3 buckets with continuous + snapshots"]
  D --> E["Output: vault and plan ARNs by region"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>backup.tf</strong><dd><code>Main module orchestration with multi-region providers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-7c1ab585d694f1a79a08a69dfd06d1fb509db4d95a6f01a3675a39c59df0d91b">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>variables.tf</strong><dd><code>Root module input variables with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>outputs.tf</strong><dd><code>Root module outputs for vault and plan resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.tf</strong><dd><code>Backup vault creation with optional lock configuration</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-25bae3ddb50c62caf180db1566bae7b3ac90d3a742d75896667bfcfbf4782dad">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>variables.tf</strong><dd><code>Vault module input variables and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-86334a02da31497f4b04d33328ab90990621b1b73e62d98d827f18f27b45127e">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>outputs.tf</strong><dd><code>Vault module outputs for name, ARN, and ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-f8c2c37684beaf47343727bdefa9b92f9750a9537936b959f504192ba421fe91">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.tf</strong><dd><code>Backup plan with continuous and snapshot rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-e20ae79d74499b4477d261534eeb8841c3fabcf2cb0f114cc517e5cfb7c2ed1a">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>variables.tf</strong><dd><code>Backup plan module input variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-83e25348c45e25947f21eafcbeb3bd9762bd0e45c8a9ce4ea0cefeb5325f7264">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>outputs.tf</strong><dd><code>Backup plan module outputs for plan and selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-3200fd339e5811c4053e95f89b8b5bc80d537aaadec90b8ebf6e65ea4d4981f7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>versions.tf</strong><dd><code>Terraform and provider version requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>versions.tf</strong><dd><code>Vault module provider requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-0923faa52fdb0dc32c1824bf380dffb214a60fb6e8452292691a57fd58856012">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>versions.tf</strong><dd><code>Backup plan module provider requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-0bc9f2a7d1fb0bd268b876aaec0c3144775c82cfc4b482daaf9917fc1e12aba7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docs.yml</strong><dd><code>GitHub workflow for automated terraform docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release.yml</strong><dd><code>Release notes configuration with changelog categories</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>labeler.yml</strong><dd><code>GitHub labeler configuration for release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-d3b620dd3f021b514e010ba2c7e6ed3dd6b6256210872d60b8b8c0af8e700f7d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Comprehensive module documentation with examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+136/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>.header.md</strong><dd><code>Header documentation for terraform-docs generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.tf</strong><dd><code>Complete example with multi-region configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-07f337e38ed1996f30ee4f04357ab23318c254cb606aaf4745d564cbd546722d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.terraform-docs.yml</strong></td>
  <td><a href="https://github.com/GlueOps/opentofu-module-aws-backup/pull/1/files#diff-1870602938553c78bf18176e356ff2e25b50db7bdae4b6421f0b1b6bdd5a026d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).